### PR TITLE
Fix: outdated post info flashing on screen

### DIFF
--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -29,7 +29,7 @@ export default function PostDetail(url: IURL) {
     
     const { data: session } = useSession()
     const { data, isLoading } = useQuery<PostType>({
-        queryKey: ['detail-post'],
+        queryKey: ['detail-post', url.params.slug],
         queryFn: () => fecthDetails(url.params.slug)
     })
 


### PR DESCRIPTION
When accessing one post then going to another one, the info of the previous post is shown for a few `ms`, using slug as a key prevents this from happening, but also keeps the cache